### PR TITLE
Connect frontend to Zuplo gateway (remove Google dependency)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Public gateway endpoint for Zuplo proxy
+NEXT_PUBLIC_GATEWAY_URL=https://downtime-places-main-f4012b8.d2.zuplo.dev

--- a/lib/api/gateway.ts
+++ b/lib/api/gateway.ts
@@ -1,0 +1,133 @@
+const GATEWAY_URL =
+  process.env.NEXT_PUBLIC_GATEWAY_URL ||
+  "https://downtime-places-main-f4012b8.d2.zuplo.dev";
+
+if (!GATEWAY_URL) {
+  throw new Error("NEXT_PUBLIC_GATEWAY_URL is not set");
+}
+
+export type GatewayPlace = {
+  place_id: string;
+  provider: "cache" | "fsq" | "yelp" | string;
+  name: string;
+  categories: string[];
+  primary_category: string;
+  category_label: string;
+  lat: number;
+  lng: number;
+  address: string;
+  city: string;
+  region: string;
+  postal_code: string;
+  country: string;
+  website: string | null;
+  phone: string | null;
+  distance_m: number;
+  open_now: boolean;
+  closing_soon: boolean;
+  todayClosingTime: string | null;
+  travel?: {
+    walk_min: number | null;
+    drive_min: number | null;
+  };
+  rating?: number | null;
+};
+
+export type PlacesResponse = {
+  source: string;
+  places: GatewayPlace[];
+  categories_available: { name: string; count: number }[];
+  duration_ms: number;
+};
+
+export async function fetchPlacesFromGateway({
+  lat,
+  lng,
+  radius_m = 1000,
+  categories,
+}: {
+  lat: number;
+  lng: number;
+  radius_m?: number;
+  categories?: string;
+}): Promise<PlacesResponse> {
+  const params = new URLSearchParams({
+    lat: lat.toString(),
+    lng: lng.toString(),
+    radius_m: radius_m.toString(),
+  });
+
+  if (categories) {
+    params.set("categories", categories);
+  }
+
+  const url = `${GATEWAY_URL.replace(/\/$/, "")}/places?${params.toString()}`;
+  console.log("[Gateway] Fetching places:", url);
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Gateway error: ${response.status}`);
+  }
+
+  const data = (await response.json()) as PlacesResponse;
+  console.log(
+    "[Gateway] Received:",
+    Array.isArray(data.places) ? data.places.length : 0,
+    "places from",
+    data.source
+  );
+  return data;
+}
+
+export type GeocodeResponse = {
+  location: { lat: number; lng: number };
+};
+
+export async function geocodeFromGateway(query: string): Promise<GeocodeResponse> {
+  const url = `${GATEWAY_URL.replace(/\/$/, "")}/geocode?query=${encodeURIComponent(
+    query
+  )}`;
+  console.log("[Gateway] Geocoding:", query);
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Geocode error: ${response.status}`);
+  }
+
+  return (await response.json()) as GeocodeResponse;
+}
+
+export type TravelTimesResponse = {
+  results: Array<{
+    id: string;
+    drivingMinutes: number | null;
+    walkingMinutes: number | null;
+  }>;
+};
+
+export async function getTravelTimesFromGateway(
+  origin: { lat: number; lng: number },
+  destinations: Array<{ id?: string; lat: number; lng: number }>
+): Promise<TravelTimesResponse> {
+  const url = `${GATEWAY_URL.replace(/\/$/, "")}/travel-times`;
+  console.log("[Gateway] Fetching travel times for", destinations.length, "destinations");
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      origin,
+      destinations: destinations.map((dest, index) => ({
+        id: dest.id ?? String(index),
+        lat: dest.lat,
+        lng: dest.lng,
+      })),
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Travel times error: ${response.status}`);
+  }
+
+  return (await response.json()) as TravelTimesResponse;
+}

--- a/pages/api/geocode.ts
+++ b/pages/api/geocode.ts
@@ -1,4 +1,33 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+import { geocodeFromGateway } from "@/lib/api/gateway";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const query = req.query.query as string | undefined;
+  if (!query) {
+    return res.status(400).json({ error: "Missing query" });
+  }
+
+  try {
+    const data = await geocodeFromGateway(query);
+    return res.status(200).json(data);
+  } catch (error: any) {
+    console.error("[Geocode API] Gateway proxy error", error?.message || error);
+    return res.status(500).json({ error: "Geocode error" });
+  }
+}
+
+/*
+Legacy Google Geocoding implementation preserved for rollback.
+
+import type { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { query } = req.query;
@@ -32,3 +61,4 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       .json({ error: e.message || "Geocode error" });
   }
 }
+*/

--- a/pages/api/places.ts
+++ b/pages/api/places.ts
@@ -1,5 +1,90 @@
 // pages/api/places.ts
 import type { NextApiRequest, NextApiResponse } from "next";
+import {
+  GatewayPlace,
+  fetchPlacesFromGateway,
+} from "@/lib/api/gateway";
+
+type NearbyResult = {
+  place_id: string;
+  name: string;
+  vicinity?: string;
+  geometry?: { location: { lat: number; lng: number } };
+  opening_hours?: { open_now?: boolean };
+  rating?: number | null;
+  user_ratings_total?: number;
+  types?: string[];
+  distanceKm?: number;
+  formatted_phone_number?: string | null;
+  website?: string | null;
+  url?: string;
+};
+
+type Resp = NearbyResult[];
+
+function transformPlace(place: GatewayPlace): NearbyResult {
+  const geometry = {
+    location: { lat: place.lat, lng: place.lng },
+  };
+
+  return {
+    place_id: place.place_id,
+    name: place.name,
+    vicinity: place.address,
+    geometry,
+    opening_hours: { open_now: place.open_now },
+    rating: place.rating ?? null,
+    types: place.categories,
+    distanceKm: place.distance_m ? place.distance_m / 1000 : undefined,
+    formatted_phone_number: place.phone,
+    website: place.website ?? undefined,
+    url: `https://www.google.com/maps/place/?q=place_id:${encodeURIComponent(
+      place.place_id
+    )}`,
+  };
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const lat = Number(req.query.lat);
+    const lng = Number(req.query.lng);
+    const radius = Number(req.query.radius ?? req.query.radius_m ?? 1000);
+    const categories = (req.query.categories as string | undefined) ?? undefined;
+
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+      return res.status(400).json({ error: "lat & lng required" });
+    }
+
+    const data = await fetchPlacesFromGateway({
+      lat,
+      lng,
+      radius_m: Number.isFinite(radius) ? radius : 1000,
+      categories,
+    });
+
+    const transformed: Resp = Array.isArray(data.places)
+      ? data.places.map(transformPlace)
+      : [];
+
+    return res.status(200).json(transformed);
+  } catch (error: any) {
+    console.error("[Places API] Gateway proxy error", error?.message || error);
+    return res.status(500).json({ error: "Failed to fetch places" });
+  }
+}
+
+/*
+Previous Google Places implementation retained for reference during rollout.
+
+import type { NextApiRequest, NextApiResponse } from "next";
 
 type NearbyResult = {
   place_id: string;
@@ -157,3 +242,4 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(500).json({ error: err?.message || "Internal error" });
   }
 }
+*/

--- a/pages/api/travel-times.ts
+++ b/pages/api/travel-times.ts
@@ -1,5 +1,55 @@
 // pages/api/travel-times.ts
 import type { NextApiRequest, NextApiResponse } from "next";
+import { getTravelTimesFromGateway } from "@/lib/api/gateway";
+
+type LatLng = { lat: number; lng: number };
+type Dest = { id: string; lat: number; lng: number };
+
+type TravelTimesResult = {
+  id: string;
+  drivingMinutes: number | null;
+  walkingMinutes: number | null;
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const { origin, destinations } = req.body as {
+      origin: LatLng;
+      destinations: Dest[];
+    };
+
+    if (!origin || !destinations?.length) {
+      return res.status(400).json({ error: "origin and destinations[] required" });
+    }
+
+    const gatewayResponse = await getTravelTimesFromGateway(origin, destinations);
+    const results: TravelTimesResult[] = gatewayResponse.results.map((item, index) => ({
+      id: destinations[index]?.id ?? item.id,
+      drivingMinutes: item.drivingMinutes,
+      walkingMinutes: item.walkingMinutes,
+    }));
+
+    return res.status(200).json({ results });
+  } catch (error: any) {
+    console.error("[Travel Times API] Gateway proxy error", error?.message || error);
+    return res
+      .status(500)
+      .json({ error: error?.message || "Failed to fetch travel times" });
+  }
+}
+
+/*
+Original Google Distance Matrix implementation preserved for reference.
+
+import type { NextApiRequest, NextApiResponse } from "next";
 
 type LatLng = { lat: number; lng: number };
 type Dest = { id: string; lat: number; lng: number };
@@ -71,3 +121,4 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       .json({ error: e?.message || "Failed to fetch travel times" });
   }
 }
+*/


### PR DESCRIPTION
## Changes
- Created `/lib/api/gateway.ts` client library for Zuplo endpoints
- Updated `/pages/api/places.ts` to proxy through the Zuplo gateway while preserving the previous Google implementation in comments
- Updated `/pages/api/geocode.ts` to use the gateway geocoding endpoint with legacy code commented for rollback
- Updated `/pages/api/travel-times.ts` to call the gateway travel-times endpoint with the prior Google logic retained in comments
- Added `.env.example` with the required `NEXT_PUBLIC_GATEWAY_URL`

## Testing
- [ ] Build passes (`npm run build`) – blocked in container because Google Fonts CDN is unreachable (`Plus Jakarta Sans` download fails)
- [x] TypeScript checks pass (`next build` completed the lint/type phase before the font download failure)
- [x] All imports resolve correctly
- [ ] Manual testing: places appear on map (reviewer to confirm)
- [ ] Manual testing: no Google API calls in Network tab (reviewer to confirm)

## Rollback Plan
If issues arise, revert this PR. Old Google implementation preserved in git history.

## Related
- Gateway URL: https://downtime-places-main-f4012b8.d2.zuplo.dev


------
https://chatgpt.com/codex/tasks/task_e_68e47202a0508323baeef2b3475f513f